### PR TITLE
change mustache pkg for compiling with dart2native

### DIFF
--- a/lib/sitegen.dart
+++ b/lib/sitegen.dart
@@ -16,7 +16,7 @@ import 'package:validate/validate.dart';
 
 import "package:path/path.dart" as path;
 import "package:markdown/markdown.dart" as md;
-import "package:mustache/mustache.dart" as mustache;
+import "package:reflected_mustache/mustache.dart" as mustache;
 import "package:yaml/yaml.dart" as yaml;
 
 import 'package:http_server/http_server.dart';
@@ -36,11 +36,7 @@ bool _runsOnOSX() => (SysInfo.operatingSystemName == "Mac OS X");
 // final _commands = new List<CommandWrapper>();
 
 Future main(List<String> arguments) async {
-    final Application application = new Application();
+  final Application application = new Application();
 
-    application.run( arguments );
+  application.run(arguments);
 }
-
-
-
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   yaml: ^2.1.0
   path: ^1.0.0
   markdown: ^2.0.0
-  mustache: ^1.0.0
+  reflected_mustache: ^1.0.0
   intl: ^0.15.0
   http_server: ^0.9.0
 


### PR DESCRIPTION
Use reflected_mustache package to avoid mustache packages usage of dart:mirrors to allow sitegen to be compiled with dart2native.