### PR TITLE
Fix frontmatter yaml maps lists

### DIFF
--- a/lib/sitegen.dart
+++ b/lib/sitegen.dart
@@ -16,7 +16,7 @@ import 'package:validate/validate.dart';
 
 import "package:path/path.dart" as path;
 import "package:markdown/markdown.dart" as md;
-import "package:mustache/mustache.dart" as mustache;
+import "package:reflected_mustache/mustache.dart" as mustache;
 import "package:yaml/yaml.dart" as yaml;
 
 import 'package:http_server/http_server.dart';
@@ -36,11 +36,7 @@ bool _runsOnOSX() => (SysInfo.operatingSystemName == "Mac OS X");
 // final _commands = new List<CommandWrapper>();
 
 Future main(List<String> arguments) async {
-    final Application application = new Application();
+  final Application application = new Application();
 
-    application.run( arguments );
+  application.run(arguments);
 }
-
-
-
-

--- a/lib/src/Generator.dart
+++ b/lib/src/Generator.dart
@@ -66,8 +66,15 @@ class Generator {
                     final String block = yamlBlock.join('\n');
                     final yaml.YamlMap ym = yaml.loadYaml(block);
 
-                    pageOptions.addAll(ym.map((key,value)
-                        => MapEntry<String,String>(key.toString(),value.toString())));
+                    pageOptions.addAll(ym.map((key, value) {
+                      if (value is yaml.YamlList) {
+                        return MapEntry<String, yaml.YamlList>(key.toString(), value);
+                      }
+                      if (value is yaml.YamlMap) {
+                        return MapEntry<String, yaml.YamlMap>(key.toString(), value);
+                      }
+                        return MapEntry<String, String>(key.toString(), value.toString());
+                    }));
 
                     _resolvePartialsInYamlBlock(partialsDir,pageOptions,config.usemarkdown);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   yaml: ^2.1.0
   path: ^1.0.0
   markdown: ^2.0.0
-  mustache: ^1.0.0
+  reflected_mustache: ^1.0.0
   intl: ^0.15.0
   http_server: ^0.9.0
 


### PR DESCRIPTION
This fixes a bug where lists and maps were being incorrectly converted to strings when being read out of yaml frontmatter in html and md files.

Fixes: #3 

Please note that this PR is stacked on top of #2. I can rebase it off master if that PR is not eventually merged in.